### PR TITLE
Update to doc.py to fix html/cgi import problem

### DIFF
--- a/anaconda_server/commands/doc.py
+++ b/anaconda_server/commands/doc.py
@@ -5,12 +5,22 @@
 import sys
 import logging
 
-try:
+# Old approach:
+# try:
+#     import html
+# except ImportError:
+#     # python2 faillback
+#     import cgi
+#     from HTMLParser import HTMLParser
+
+# New approach:
+if sys.version_info >= (3, 0):
     import html
-except ImportError:
+else:
     # python2 faillback
     import cgi
     from HTMLParser import HTMLParser
+
 
 from .base import Command
 


### PR DESCRIPTION
Doc._html uses a direct check on the python version while the import tries to rely on importing html failing.  Related to #476, this is a problem if an html package is installed in Python 2 and doesn't trigger the exception.  Instead just using the same version check from Doc._html
